### PR TITLE
Add error handlers to more signature provider functions

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,86 @@
+API definitions for modules
+===========================
+
+This document defines which functions have to be implemented by modules to be usable with this package.
+
+Signature providers
+-------------------
+
+### `NewProvider`
+
+```go
+NewProvider(parameters string) (Provider, []publickey.PublicKey, error)
+```
+
+`NewProvider` has to create a new Provider optionally taking in parameters as a string.
+It has to generate new keys and return the public keys (in case there are any - see HMAC-SHA2).
+A key ID should also be generated for every new key and should be included with the public keys.
+
+### `NewProviderWithKeyURL`
+
+```go
+NewProviderWithKeyURL(parameters string, keyURL string) (Provider, []publickey.PublicKey, error)
+```
+
+`NewProviderWithKeyURL` has to work the same as `NewProvider` but must also add the key URL so that is is available to the `Header` function of the provider.
+
+### `LoadProvider`
+
+```go
+LoadProvider(set KeySet..., parameters string) (Provider, error)
+```
+
+`LoadProvider` may be provided to enable users to load keys.
+The function may take as many `KeySet`s as necessary for the algorithm the provider implements.
+Optional parameters should be taken from a string.
+Please note that each needed `KeySet` must be it's own parameter instead of some taking kind of array (no rest of parameters either).
+
+### `Provider`
+
+```go
+type Provider interface {
+	Sign([]byte) ([]byte, error)
+	Verify([]byte, []byte, Header) error
+	Header(*Header)
+}
+```
+
+A `Provider` has to implement the following functionality:
+
+`Sign(data []byte) (signature []byte, err error)` has to return the (not base64-encoded) signature the algorithm generates for the data provided as the input and an error to indicate whether signing was successful.
+
+`Verify(data, signature []byte, h Header) (err error)` has to return an error indicating whether the signature could be validated. The header can be accessed for additional data.
+
+`Header(h *Header)` has to set the necessary header parameters to indicate the used algorithm. It must also set the key ID and key URL in case the key designated for signing has any.
+
+In case additional fields in the header are necessary, please open an issue on GitHub to discuss possible solutions.
+
+### `KeySet`
+
+```go
+type KeySet interface {
+	SetKeys([]byte, []byte) error
+	SetKeyID(string)
+	SetKeyURL(string)
+	GetPublicKey() publickey.PublicKey
+}
+```
+
+A `KeySet` is only necessary when supporting `LoadProvider` and has to implement the following functionality:
+
+`SetKeys(privateKey, publicKey []byte) (err error)` has to set the keys of the `KeySet` by parsing the supplied byte slices and return an error indicating whether parsing was successful.
+
+`SetKeyID(keyID string)` has to set the key ID of the `KeySet`
+
+`SetKeyURL(keyURL string)` has to set the key URL of the `KeySet`
+
+`GetPublicKey() publicKey publickey.PublicKey` has to return the public key (as a byte slice) and key ID of the `KeySet` as a `publickey.PublicKey`
+
+Validation providers
+--------------------
+
+```go
+func Validate(content []byte) error
+```
+
+A validation provider consists of a single function taking a byte slice containing the JSON-encoded body of the token and returns an error indication whether the token is valid. It has to unmarshal the JSON and perform all necessary checks to determine the validity of the claims.

--- a/API.md
+++ b/API.md
@@ -49,7 +49,7 @@ A `Provider` has to implement the following functionality:
 
 `Sign(data []byte) (signature []byte, err error)` has to return the (not base64-encoded) signature the algorithm generates for the data provided as the input and an error to indicate whether signing was successful.
 
-`Verify(data, signature []byte, h Header) (err error)` has to return an error indicating whether the signature could be validated. The header can be accessed for additional data.
+`Verify(data, signature []byte, h Header) (err error)` has to return an error indicating whether the signature could be validated. The header can be accessed for additional data. The error may present information about an internal issue with validating like a missing key but an invalid signature must be indicated only by returning `errors.New("signature invalid")`. This is for security purposes as a developer may want to forward this error to the user and too much information about the verification process could cause issues.
 
 `Header(h *Header)` has to set the necessary header parameters to indicate the used algorithm. It must also set the key ID and key URL in case the key designated for signing has any.
 

--- a/alg-eddsa/eddsa.go
+++ b/alg-eddsa/eddsa.go
@@ -52,12 +52,12 @@ func NewProviderWithKeyURL(defaultCurve, keyURL string) (Provider, []publickey.P
 }
 
 // LoadProvider returns a Provider using the supplied keypairs
-func LoadProvider(k2 Ed25519KeySet, k4 Ed448KeySet, defaultCurve string) Provider {
+func LoadProvider(k2 Ed25519KeySet, k4 Ed448KeySet, defaultCurve string) (Provider, error) {
 	if defaultCurve != Ed25519 && defaultCurve != Ed448 {
-		return Provider{}
+		return Provider{}, errors.New("unknown curve supplied as default curve")
 	}
 	c := ed448.NewCurve()
-	return Provider{k2, k4, c, defaultCurve}
+	return Provider{k2, k4, c, defaultCurve}, nil
 }
 
 // Header sets the necessary JWT header fields for the default curve

--- a/alg-eddsa/eddsa.go
+++ b/alg-eddsa/eddsa.go
@@ -83,24 +83,24 @@ func (p Provider) Header(h *jwt.Header) {
 }
 
 // Sign signs the content of a JWT using the default curve
-func (p Provider) Sign(c []byte) []byte {
+func (p Provider) Sign(c []byte) ([]byte, error) {
 	switch p.defaultCurve {
 	case Ed25519:
 		if !p.ed25519keyset.canSign {
-			return nil
+			return nil, errors.New("keyset does not allow signing")
 		}
-		return ed25519.Sign(p.ed25519keyset.private, c)
+		return ed25519.Sign(p.ed25519keyset.private, c), nil
 	case Ed448:
 		if !p.ed448keyset.canSign {
-			return nil
+			return nil, errors.New("keyset does not allow signing")
 		}
 		sig, ok := p.ed448curve.Sign(p.ed448keyset.private, c)
 		if !ok {
-			return nil
+			return nil, errors.New("signing failed")
 		}
-		return sig[:]
+		return sig[:], nil
 	}
-	return nil
+	return nil, errors.New("unknown curve")
 }
 
 // Verify verifies if the content matches it's signature. The curve to use is set by the header.

--- a/alg-eddsa/eddsa_test.go
+++ b/alg-eddsa/eddsa_test.go
@@ -154,15 +154,15 @@ func TestProvider_Sign(t *testing.T) {
 
 func TestProvider_Verify(t *testing.T) {
 	p25519 := Provider{Ed25519KeySet{canVerify: false}, Ed448KeySet{}, ed448.NewCurve(), ""}
-	if p25519.Verify(nil, nil, jwt.Header{Crv: Ed25519}) != false {
+	if p25519.Verify(nil, nil, jwt.Header{Crv: Ed25519}) == nil {
 		t.Error("Provider.Verify() should fail because canVerify is false for specified curve")
 	}
 	p448 := Provider{Ed25519KeySet{}, Ed448KeySet{canVerify: false}, ed448.NewCurve(), ""}
-	if p448.Verify(nil, nil, jwt.Header{Crv: Ed448}) != false {
+	if p448.Verify(nil, nil, jwt.Header{Crv: Ed448}) == nil {
 		t.Error("Provider.Verify() should fail because canVerify is false for specified curve")
 	}
 	punknown := Provider{Ed25519KeySet{}, Ed448KeySet{}, ed448.NewCurve(), ""}
-	if punknown.Verify(nil, nil, jwt.Header{Crv: "unknown"}) != false {
+	if punknown.Verify(nil, nil, jwt.Header{Crv: "unknown"}) == nil {
 		t.Error("Provider.Verify() should fail because specified curve is unknown")
 	}
 }

--- a/alg-eddsa/eddsa_test.go
+++ b/alg-eddsa/eddsa_test.go
@@ -135,15 +135,19 @@ func TestProvider_Header(t *testing.T) {
 
 func TestProvider_Sign(t *testing.T) {
 	p25519 := Provider{Ed25519KeySet{canSign: false}, Ed448KeySet{}, ed448.NewCurve(), Ed25519}
-	if p25519.Sign(nil) != nil {
+	if _, err := p25519.Sign(nil); err == nil {
 		t.Error("Provider.Sign() should fail because canSign is false for default curve")
 	}
 	p448 := Provider{Ed25519KeySet{}, Ed448KeySet{canSign: false}, ed448.NewCurve(), Ed448}
-	if p448.Sign(nil) != nil {
+	if _, err := p448.Sign(nil); err == nil {
 		t.Error("Provider.Sign() should fail because canSign is false for default curve")
 	}
+	p448invalid := Provider{Ed25519KeySet{}, Ed448KeySet{private: [144]byte{33, 147, 45, 233, 236, 0, 92, 221, 111, 132, 50, 172, 83, 220, 197, 251, 46, 83, 98, 113, 173, 250, 128, 15, 127, 85, 149, 81, 253, 149, 84, 233, 76, 193, 173, 2, 193, 133, 5, 110, 215, 167, 6, 246, 145, 232, 50, 246, 120, 203, 191, 73, 226, 187, 134, 244, 139, 144, 55, 7, 217, 55, 48, 50, 59, 69, 52, 245, 17, 88, 150, 144, 192, 86, 215, 194, 107, 27, 105, 18, 204, 119, 213, 231, 70, 116, 232, 126, 57, 115, 221, 8, 152, 154, 20, 204, 37, 255, 227, 237, 136, 58, 151, 207, 108, 214, 113, 87, 22, 144, 227, 121, 79, 213, 114, 45, 207, 192, 160, 60, 193, 149, 53, 220, 34, 103, 37, 25, 90, 18, 60, 190, 209, 191, 147, 242, 127, 173, 86, 221, 233, 192, 44, 167}, canSign: true}, ed448.NewCurve(), Ed448}
+	if _, err := p448invalid.Sign(nil); err == nil {
+		t.Error("Provider.Sign() should fail because Ed448 private key is invalid")
+	}
 	punknown := Provider{Ed25519KeySet{}, Ed448KeySet{}, ed448.NewCurve(), "unknown"}
-	if punknown.Sign(nil) != nil {
+	if _, err := punknown.Sign(nil); err == nil {
 		t.Error("Provider.Sign() should fail because default curve is unknown")
 	}
 }

--- a/alg-eddsa/eddsa_test.go
+++ b/alg-eddsa/eddsa_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fossoreslp/go-jwt"
 	"github.com/otrv4/ed448"
+	"golang.org/x/crypto/ed25519"
 )
 
 func TestNewProvider(t *testing.T) {
@@ -158,13 +159,21 @@ func TestProvider_Sign(t *testing.T) {
 }
 
 func TestProvider_Verify(t *testing.T) {
-	p25519 := Provider{Ed25519KeySet{canVerify: false}, Ed448KeySet{}, ed448.NewCurve(), ""}
+	p25519 := Provider{Ed25519KeySet{public: ed25519.PublicKey{0x9a, 0xe1, 0x6f, 0x74, 0x0d, 0xc1, 0x49, 0x0a, 0xa7, 0x36, 0x9f, 0xb5, 0xce, 0x09, 0xe6, 0x07, 0xa3, 0xd9, 0x78, 0xd4, 0x8e, 0xa2, 0x87, 0x19, 0x1e, 0x92, 0x95, 0x5b, 0xa2, 0x9d, 0x74, 0xb2}, canVerify: false}, Ed448KeySet{}, ed448.NewCurve(), Ed25519}
 	if p25519.Verify(nil, nil, jwt.Header{Crv: Ed25519}) == nil {
 		t.Error("Provider.Verify() should fail because canVerify is false for specified curve")
 	}
-	p448 := Provider{Ed25519KeySet{}, Ed448KeySet{canVerify: false}, ed448.NewCurve(), ""}
+	p25519.ed25519keyset.canVerify = true
+	if p25519.Verify([]byte("test"), []byte("signature"), jwt.Header{Crv: Ed25519}) == nil {
+		t.Error("Provider.Verify() should fail for invalid signature")
+	}
+	p448 := Provider{Ed25519KeySet{}, Ed448KeySet{public: [56]byte{0x65, 0x0d, 0x46, 0xb1, 0x0c, 0x4f, 0xd2, 0x2e, 0xd9, 0x4c, 0x97, 0x34, 0x49, 0x88, 0x16, 0xd1, 0xc8, 0x6a, 0x34, 0xa7, 0xae, 0x4d, 0xcb, 0x81, 0x4c, 0xd9, 0x45, 0xfb, 0x31, 0x4d, 0xe2, 0xaa, 0x04, 0xde, 0x17, 0xee, 0xf5, 0xae, 0x27, 0x29, 0xa0, 0x33, 0x25, 0x98, 0x27, 0x3f, 0xce, 0x9d, 0xe1, 0x4c, 0xf3, 0x24, 0x6b, 0x89, 0x4b, 0x60}, canVerify: false}, ed448.NewCurve(), Ed448}
 	if p448.Verify(nil, nil, jwt.Header{Crv: Ed448}) == nil {
 		t.Error("Provider.Verify() should fail because canVerify is false for specified curve")
+	}
+	p448.ed448keyset.canVerify = true
+	if p448.Verify([]byte("test"), []byte("signature"), jwt.Header{Crv: Ed448}) == nil {
+		t.Error("Provider.Verify() should fail for invalid signature")
 	}
 	punknown := Provider{Ed25519KeySet{}, Ed448KeySet{}, ed448.NewCurve(), ""}
 	if punknown.Verify(nil, nil, jwt.Header{Crv: "unknown"}) == nil {

--- a/alg-eddsa/eddsa_test.go
+++ b/alg-eddsa/eddsa_test.go
@@ -6,9 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/otrv4/ed448"
-
 	"github.com/fossoreslp/go-jwt"
+	"github.com/otrv4/ed448"
 )
 
 func TestNewProvider(t *testing.T) {
@@ -84,17 +83,23 @@ func TestLoadProvider(t *testing.T) {
 		defaultCurve string
 	}
 	tests := []struct {
-		name string
-		args args
-		want Provider
+		name    string
+		args    args
+		want    Provider
+		wantErr bool
 	}{
-		{"Ed25519", args{Ed25519KeySet{}, Ed448KeySet{}, Ed25519}, Provider{Ed25519KeySet{}, Ed448KeySet{}, ed448.NewCurve(), Ed25519}},
-		{"Ed448", args{Ed25519KeySet{}, Ed448KeySet{}, Ed448}, Provider{Ed25519KeySet{}, Ed448KeySet{}, ed448.NewCurve(), Ed448}},
-		{"Unknown", args{Ed25519KeySet{}, Ed448KeySet{}, "unknown"}, Provider{}},
+		{"Ed25519", args{Ed25519KeySet{}, Ed448KeySet{}, Ed25519}, Provider{Ed25519KeySet{}, Ed448KeySet{}, ed448.NewCurve(), Ed25519}, false},
+		{"Ed448", args{Ed25519KeySet{}, Ed448KeySet{}, Ed448}, Provider{Ed25519KeySet{}, Ed448KeySet{}, ed448.NewCurve(), Ed448}, false},
+		{"Unknown", args{Ed25519KeySet{}, Ed448KeySet{}, "unknown"}, Provider{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := LoadProvider(tt.args.k2, tt.args.k4, tt.args.defaultCurve); !reflect.DeepEqual(got, tt.want) {
+			got, err := LoadProvider(tt.args.k2, tt.args.k4, tt.args.defaultCurve)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LoadProvider() = %v, want %v", got, tt.want)
 			}
 		})

--- a/alg-es/es.go
+++ b/alg-es/es.go
@@ -143,12 +143,12 @@ func (p Provider) Sign(c []byte) ([]byte, error) {
 }
 
 // Verify verifies if the content matches it's signature.
-func (p Provider) Verify(data, sig []byte, h jwt.Header) bool {
+func (p Provider) Verify(data, sig []byte, h jwt.Header) error {
 	if !p.set.canVerify {
-		return false
+		return errors.New("keyset does not allow validation")
 	}
 	if len(sig) != 2*p.ilen {
-		return false
+		return errors.New("signature invalid")
 	}
 	hash := p.hash.New()
 	hash.Write(data)
@@ -156,5 +156,8 @@ func (p Provider) Verify(data, sig []byte, h jwt.Header) bool {
 	s := big.Int{}
 	r.SetBytes(sig[:p.ilen])
 	s.SetBytes(sig[p.ilen:])
-	return ecdsa.Verify(p.set.public, hash.Sum(nil), &r, &s)
+	if ecdsa.Verify(p.set.public, hash.Sum(nil), &r, &s) {
+		return nil
+	}
+	return errors.New("signature invalid")
 }

--- a/alg-es/es.go
+++ b/alg-es/es.go
@@ -108,15 +108,15 @@ func (p Provider) Header(h *jwt.Header) {
 }
 
 // Sign signs the content of a JWT
-func (p Provider) Sign(c []byte) []byte {
+func (p Provider) Sign(c []byte) ([]byte, error) {
 	if !p.set.canSign {
-		return nil
+		return nil, errors.New("keyset does not allow signing")
 	}
 	hash := p.hash.New()
 	hash.Write(c)
 	r, s, err := ecdsa.Sign(rand.Reader, p.set.private, hash.Sum(nil))
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	rb := r.Bytes()
@@ -139,7 +139,7 @@ func (p Provider) Sign(c []byte) []byte {
 		sb = append(p, sb...)
 	}
 
-	return append(rb, sb...)
+	return append(rb, sb...), nil
 }
 
 // Verify verifies if the content matches it's signature.

--- a/alg-es/es.go
+++ b/alg-es/es.go
@@ -84,16 +84,16 @@ func NewProviderWithKeyURL(t, keyURL string) (Provider, []publickey.PublicKey, e
 }
 
 // LoadProvider returns a Provider using the supplied keypairs
-func LoadProvider(k KeySet, t string) Provider {
+func LoadProvider(k KeySet, t string) (Provider, error) {
 	switch t {
 	case ES256:
-		return Provider{ES256, crypto.SHA256, k, 32}
+		return Provider{ES256, crypto.SHA256, k, 32}, nil
 	case ES384:
-		return Provider{ES384, crypto.SHA384, k, 48}
+		return Provider{ES384, crypto.SHA384, k, 48}, nil
 	case ES512:
-		return Provider{ES512, crypto.SHA512, k, 66}
+		return Provider{ES512, crypto.SHA512, k, 66}, nil
 	}
-	return Provider{}
+	return Provider{}, errors.New("type string invalid")
 }
 
 // Header sets the necessary JWT header fields

--- a/alg-es/es_test.go
+++ b/alg-es/es_test.go
@@ -45,18 +45,24 @@ func TestLoadProvider(t *testing.T) {
 		t string
 	}
 	tests := []struct {
-		name string
-		args args
-		want Provider
+		name    string
+		args    args
+		want    Provider
+		wantErr bool
 	}{
-		{"RS256", args{KeySet{}, ES256}, Provider{ES256, crypto.SHA256, KeySet{}, 32}},
-		{"RS384", args{KeySet{}, ES384}, Provider{ES384, crypto.SHA384, KeySet{}, 48}},
-		{"RS512", args{KeySet{}, ES512}, Provider{ES512, crypto.SHA512, KeySet{}, 66}},
-		{"Unknown type", args{KeySet{}, "unknown"}, Provider{}},
+		{"RS256", args{KeySet{}, ES256}, Provider{ES256, crypto.SHA256, KeySet{}, 32}, false},
+		{"RS384", args{KeySet{}, ES384}, Provider{ES384, crypto.SHA384, KeySet{}, 48}, false},
+		{"RS512", args{KeySet{}, ES512}, Provider{ES512, crypto.SHA512, KeySet{}, 66}, false},
+		{"Unknown type", args{KeySet{}, "unknown"}, Provider{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := LoadProvider(tt.args.k, tt.args.t); !reflect.DeepEqual(got, tt.want) {
+			got, err := LoadProvider(tt.args.k, tt.args.t)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LoadProvider() = %v, want %v", got, tt.want)
 			}
 		})

--- a/alg-es/es_test.go
+++ b/alg-es/es_test.go
@@ -119,12 +119,12 @@ func TestProvider_Sign(t *testing.T) {
 
 func TestProvider_Verify(t *testing.T) {
 	p := Provider{set: KeySet{canVerify: false}}
-	if p.Verify(nil, nil, jwt.Header{}) != false {
-		t.Error("Verify() did not return false when canVerify is false")
+	if p.Verify(nil, nil, jwt.Header{}) == nil {
+		t.Error("Verify() did not return an error when canVerify is false")
 	}
 	p = Provider{set: KeySet{canVerify: true}, ilen: 16}
 	b := [12]byte{0xFF}
-	if p.Verify(nil, b[:], jwt.Header{}) != false {
-		t.Error("Verify() did not return false when signature has wrong length")
+	if p.Verify(nil, b[:], jwt.Header{}) == nil {
+		t.Error("Verify() did not return an error when signature has wrong length")
 	}
 }

--- a/alg-es/es_test.go
+++ b/alg-es/es_test.go
@@ -128,9 +128,13 @@ func TestProvider_Verify(t *testing.T) {
 	if p.Verify(nil, nil, jwt.Header{}) == nil {
 		t.Error("Verify() did not return an error when canVerify is false")
 	}
-	p = Provider{set: KeySet{canVerify: true}, ilen: 16}
+	p = Provider{hash: crypto.SHA256, set: KeySet{public: &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}, canVerify: true}, ilen: 32}
 	b := [12]byte{0xFF}
 	if p.Verify(nil, b[:], jwt.Header{}) == nil {
 		t.Error("Verify() did not return an error when signature has wrong length")
+	}
+	b2 := [64]byte{0xFF}
+	if p.Verify([]byte("test"), b2[:], jwt.Header{}) == nil {
+		t.Error("Verify() did not return an error when encountering a wrong signature")
 	}
 }

--- a/alg-es/es_test.go
+++ b/alg-es/es_test.go
@@ -85,8 +85,8 @@ func TestProvider_Header(t *testing.T) {
 func TestProvider_Sign(t *testing.T) {
 	// CanSign == false
 	p := Provider{set: KeySet{canSign: false}}
-	if p.Sign(nil) != nil {
-		t.Error("Sign() did not return nil when canSign is false")
+	if _, err := p.Sign(nil); err == nil {
+		t.Error("Sign() did not return an error when canSign is false")
 	}
 
 	// Save default rand.Reader
@@ -96,21 +96,23 @@ func TestProvider_Sign(t *testing.T) {
 	priv := &ecdsa.PrivateKey{PublicKey: ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}, D: d}
 	rand.Reader = bytes.NewReader(nil)
 	p = Provider{hash: crypto.SHA256, set: KeySet{private: priv, canSign: true}, ilen: 16}
-	if p.Sign(nil) != nil {
-		t.Error("Sign() did not return nil when no random data was available to generate signature")
+	if _, err := p.Sign(nil); err == nil {
+		t.Error("Sign() did not return an error when no random data was available to generate signature")
 	}
 
 	// Restore default rand.Reader
 	rand.Reader = random
 
 	// Test truncation
-	if l := len(p.Sign(nil)); l != 32 {
+	b, _ := p.Sign(nil)
+	if l := len(b); l != 32 {
 		t.Errorf("Sign() should return byte slice of length 32 but was %d", l)
 	}
 
 	// Test length extension
 	p.ilen = 128
-	if l := len(p.Sign(nil)); l != 256 {
+	b, _ = p.Sign(nil)
+	if l := len(b); l != 256 {
 		t.Errorf("Sign() should return byte slice of length 256 but was %d", l)
 	}
 }

--- a/alg-hs/hs.go
+++ b/alg-hs/hs.go
@@ -105,7 +105,10 @@ func (p Provider) Sign(c []byte) ([]byte, error) {
 }
 
 // Verify verifies if the content matches it's signature.
-func (p Provider) Verify(data, sig []byte, h jwt.Header) bool {
+func (p Provider) Verify(data, sig []byte, h jwt.Header) error {
 	expectedMAC := p.getMAC(data)
-	return hmac.Equal(sig, expectedMAC)
+	if hmac.Equal(sig, expectedMAC) {
+		return nil
+	}
+	return errors.New("signature invalid")
 }

--- a/alg-hs/hs.go
+++ b/alg-hs/hs.go
@@ -70,16 +70,16 @@ func NewProviderWithKeyURL(t, keyURL string) (Provider, []publickey.PublicKey, e
 }
 
 // LoadProvider returns a Provider using the supplied keypairs
-func LoadProvider(k KeySet, t string) Provider {
+func LoadProvider(k KeySet, t string) (Provider, error) {
 	switch t {
 	case HS256:
-		return Provider{HS256, hmac.New(sha256.New, k.key), k}
+		return Provider{HS256, hmac.New(sha256.New, k.key), k}, nil
 	case HS384:
-		return Provider{HS384, hmac.New(sha512.New384, k.key), k}
+		return Provider{HS384, hmac.New(sha512.New384, k.key), k}, nil
 	case HS512:
-		return Provider{HS512, hmac.New(sha512.New, k.key), k}
+		return Provider{HS512, hmac.New(sha512.New, k.key), k}, nil
 	}
-	return Provider{}
+	return Provider{}, errors.New("type string is invalid")
 }
 
 func (p Provider) getMAC(in []byte) []byte {

--- a/alg-hs/integration_test.go
+++ b/alg-hs/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/base64"
-	"reflect"
 	"testing"
 
 	"github.com/fossoreslp/go-jwt"
@@ -128,7 +127,7 @@ func TestHeader(t *testing.T) {
 }
 
 func TestLoadProvider(t *testing.T) {
-	k := LoadProvider(KeySet{kid: "key_id"}, HS256)
+	k, _ := LoadProvider(KeySet{kid: "key_id"}, HS256)
 	if k.alg != HS256 {
 		t.Errorf("LoadProvider() did not return a HS256 provider but %s", k.alg)
 	}
@@ -136,7 +135,7 @@ func TestLoadProvider(t *testing.T) {
 		t.Errorf("LoadProvider() did not pass the data from the input keyset onto the provider")
 	}
 
-	k = LoadProvider(KeySet{kid: "key_id"}, HS384)
+	k, _ = LoadProvider(KeySet{kid: "key_id"}, HS384)
 	if k.alg != HS384 {
 		t.Errorf("LoadProvider() did not return a HS384 provider but %s", k.alg)
 	}
@@ -144,7 +143,7 @@ func TestLoadProvider(t *testing.T) {
 		t.Errorf("LoadProvider() did not pass the data from the input keyset onto the provider")
 	}
 
-	k = LoadProvider(KeySet{kid: "key_id"}, HS512)
+	k, _ = LoadProvider(KeySet{kid: "key_id"}, HS512)
 	if k.alg != HS512 {
 		t.Errorf("LoadProvider() did not return a HS512 provider but %s", k.alg)
 	}
@@ -158,8 +157,8 @@ func TestUnknownAlgorithm(t *testing.T) {
 		t.Error("NewProvider() with an unknown algorithm type should fail but returned no error.")
 	}
 
-	if !reflect.DeepEqual(LoadProvider(KeySet{}, "unknown"), Provider{}) {
-		t.Error("LoadProvider() with an unknown algorithm type did not return nil.")
+	if _, err := LoadProvider(KeySet{}, "unknown"); err == nil {
+		t.Error("LoadProvider() with an unknown algorithm type did not return an error.")
 	}
 }
 

--- a/alg-hs/integration_test.go
+++ b/alg-hs/integration_test.go
@@ -2,7 +2,9 @@ package hs
 
 import (
 	"bytes"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"testing"
 
@@ -174,4 +176,11 @@ func TestInvalidRandomGenerator(t *testing.T) {
 		t.Error("NewProviderWithKeyURL() should fail with empty random generator for secret key")
 	}
 	rand.Reader = random
+}
+
+func TestInvalidSignature(t *testing.T) {
+	p := Provider{hmac: hmac.New(sha256.New, []byte("key"))}
+	if p.Verify([]byte("test"), []byte("signature"), jwt.Header{}) == nil {
+		t.Error("Provider.Verify() should fail with invalid signature")
+	}
 }

--- a/alg-hs/integration_test.go
+++ b/alg-hs/integration_test.go
@@ -90,7 +90,7 @@ func TestHS512(t *testing.T) {
 
 func TestHeader(t *testing.T) {
 	h := jwt.Header{Typ: "JWT"}
-	HS256Provider{kid: "key_id", jku: "key_url"}.Header(&h)
+	Provider{alg: HS256, set: KeySet{kid: "key_id", jku: "key_url"}}.Header(&h)
 	if h.Alg != HS256 {
 		t.Errorf("HS256Provider.Header() should set Alg to \"HS256\" but instead it is %q", h.Alg)
 	}
@@ -102,7 +102,7 @@ func TestHeader(t *testing.T) {
 	}
 
 	h = jwt.Header{Typ: "JWT"}
-	HS384Provider{kid: "key_id", jku: "key_url"}.Header(&h)
+	Provider{alg: HS384, set: KeySet{kid: "key_id", jku: "key_url"}}.Header(&h)
 	if h.Alg != HS384 {
 		t.Errorf("HS384Provider.Header() should set Alg to \"HS384\" but instead it is %q", h.Alg)
 	}
@@ -114,7 +114,7 @@ func TestHeader(t *testing.T) {
 	}
 
 	h = jwt.Header{Typ: "JWT"}
-	HS512Provider{kid: "key_id", jku: "key_url"}.Header(&h)
+	Provider{alg: HS512, set: KeySet{kid: "key_id", jku: "key_url"}}.Header(&h)
 	if h.Alg != HS512 {
 		t.Errorf("HS512Provider.Header() should set Alg to \"HS512\" but instead it is %q", h.Alg)
 	}
@@ -129,26 +129,26 @@ func TestHeader(t *testing.T) {
 
 func TestLoadProvider(t *testing.T) {
 	k := LoadProvider(KeySet{kid: "key_id"}, HS256)
-	if _, ok := k.(HS256Provider); !ok {
-		t.Errorf("LoadProvider() did not return a HS256 provider but %s", reflect.TypeOf(k).String())
+	if k.alg != HS256 {
+		t.Errorf("LoadProvider() did not return a HS256 provider but %s", k.alg)
 	}
-	if k.(HS256Provider).kid != "key_id" {
+	if k.set.kid != "key_id" {
 		t.Errorf("LoadProvider() did not pass the data from the input keyset onto the provider")
 	}
 
 	k = LoadProvider(KeySet{kid: "key_id"}, HS384)
-	if _, ok := k.(HS384Provider); !ok {
-		t.Errorf("LoadProvider() did not return a HS384 provider but %s", reflect.TypeOf(k).String())
+	if k.alg != HS384 {
+		t.Errorf("LoadProvider() did not return a HS384 provider but %s", k.alg)
 	}
-	if k.(HS384Provider).kid != "key_id" {
+	if k.set.kid != "key_id" {
 		t.Errorf("LoadProvider() did not pass the data from the input keyset onto the provider")
 	}
 
 	k = LoadProvider(KeySet{kid: "key_id"}, HS512)
-	if _, ok := k.(HS512Provider); !ok {
-		t.Errorf("LoadProvider() did not return a HS512 provider but %s", reflect.TypeOf(k).String())
+	if k.alg != HS512 {
+		t.Errorf("LoadProvider() did not return a HS512 provider but %s", k.alg)
 	}
-	if k.(HS512Provider).kid != "key_id" {
+	if k.set.kid != "key_id" {
 		t.Errorf("LoadProvider() did not pass the data from the input keyset onto the provider")
 	}
 }
@@ -158,7 +158,7 @@ func TestUnknownAlgorithm(t *testing.T) {
 		t.Error("NewProvider() with an unknown algorithm type should fail but returned no error.")
 	}
 
-	if LoadProvider(KeySet{}, "unknown") != nil {
+	if !reflect.DeepEqual(LoadProvider(KeySet{}, "unknown"), Provider{}) {
 		t.Error("LoadProvider() with an unknown algorithm type did not return nil.")
 	}
 }

--- a/alg-ps/integration_test.go
+++ b/alg-ps/integration_test.go
@@ -100,7 +100,7 @@ o2kQ+X5xK9cipRgEKwIDAQAB
 		t.Errorf("Could not decode key: %s", err.Error())
 		t.FailNow()
 	}
-	p := LoadProvider(ks, PS384)
+	p, _ := LoadProvider(ks, PS384)
 	jwt.SetAlgorithm(PS384, p)
 	jwt.DefaultAlgorithm(PS384)
 	dec, err := jwt.Decode(token)

--- a/alg-ps/ps.go
+++ b/alg-ps/ps.go
@@ -69,16 +69,16 @@ func NewProviderWithKeyURL(t, keyURL string) (Provider, []publickey.PublicKey, e
 }
 
 // LoadProvider returns a Provider using the supplied keypairs
-func LoadProvider(k KeySet, t string) Provider {
+func LoadProvider(k KeySet, t string) (Provider, error) {
 	switch t {
 	case PS256:
-		return Provider{PS256, &rsa.PSSOptions{SaltLength: 32, Hash: crypto.SHA256}, k}
+		return Provider{PS256, &rsa.PSSOptions{SaltLength: 32, Hash: crypto.SHA256}, k}, nil
 	case PS384:
-		return Provider{PS384, &rsa.PSSOptions{SaltLength: 48, Hash: crypto.SHA384}, k}
+		return Provider{PS384, &rsa.PSSOptions{SaltLength: 48, Hash: crypto.SHA384}, k}, nil
 	case PS512:
-		return Provider{PS512, &rsa.PSSOptions{SaltLength: 64, Hash: crypto.SHA512}, k}
+		return Provider{PS512, &rsa.PSSOptions{SaltLength: 64, Hash: crypto.SHA512}, k}, nil
 	}
-	return Provider{}
+	return Provider{}, errors.New("type string invalid")
 }
 
 // Header sets the necessary JWT header fields

--- a/alg-ps/ps.go
+++ b/alg-ps/ps.go
@@ -107,11 +107,14 @@ func (p Provider) Sign(c []byte) ([]byte, error) {
 }
 
 // Verify verifies if the content matches it's signature.
-func (p Provider) Verify(data, sig []byte, h jwt.Header) bool {
+func (p Provider) Verify(data, sig []byte, h jwt.Header) error {
 	if !p.set.canVerify {
-		return false
+		return errors.New("keyset does not allow validation")
 	}
 	hash := p.pssopts.Hash.New()
 	hash.Write(data)
-	return rsa.VerifyPSS(p.set.public, p.pssopts.Hash, hash.Sum(nil), sig, p.pssopts) == nil
+	if rsa.VerifyPSS(p.set.public, p.pssopts.Hash, hash.Sum(nil), sig, p.pssopts) == nil {
+		return nil
+	}
+	return errors.New("signature invalid")
 }

--- a/alg-ps/ps.go
+++ b/alg-ps/ps.go
@@ -93,17 +93,17 @@ func (p Provider) Header(h *jwt.Header) {
 }
 
 // Sign signs the content of a JWT
-func (p Provider) Sign(c []byte) []byte {
+func (p Provider) Sign(c []byte) ([]byte, error) {
 	if !p.set.canSign {
-		return nil
+		return nil, errors.New("keyset does not allow signing")
 	}
 	hash := p.pssopts.Hash.New()
 	hash.Write(c)
 	sum, err := rsa.SignPSS(rand.Reader, p.set.private, p.pssopts.Hash, hash.Sum(nil), p.pssopts)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return sum
+	return sum, nil
 }
 
 // Verify verifies if the content matches it's signature.

--- a/alg-ps/ps_test.go
+++ b/alg-ps/ps_test.go
@@ -45,18 +45,24 @@ func TestLoadProvider(t *testing.T) {
 		t string
 	}
 	tests := []struct {
-		name string
-		args args
-		want Provider
+		name    string
+		args    args
+		want    Provider
+		wantErr bool
 	}{
-		{"PS256", args{KeySet{}, PS256}, Provider{PS256, &rsa.PSSOptions{SaltLength: 32, Hash: crypto.SHA256}, KeySet{}}},
-		{"PS384", args{KeySet{}, PS384}, Provider{PS384, &rsa.PSSOptions{SaltLength: 48, Hash: crypto.SHA384}, KeySet{}}},
-		{"PS512", args{KeySet{}, PS512}, Provider{PS512, &rsa.PSSOptions{SaltLength: 64, Hash: crypto.SHA512}, KeySet{}}},
-		{"Unknown type", args{KeySet{}, "unknown"}, Provider{}},
+		{"PS256", args{KeySet{}, PS256}, Provider{PS256, &rsa.PSSOptions{SaltLength: 32, Hash: crypto.SHA256}, KeySet{}}, false},
+		{"PS384", args{KeySet{}, PS384}, Provider{PS384, &rsa.PSSOptions{SaltLength: 48, Hash: crypto.SHA384}, KeySet{}}, false},
+		{"PS512", args{KeySet{}, PS512}, Provider{PS512, &rsa.PSSOptions{SaltLength: 64, Hash: crypto.SHA512}, KeySet{}}, false},
+		{"Unknown type", args{KeySet{}, "unknown"}, Provider{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := LoadProvider(tt.args.k, tt.args.t); !reflect.DeepEqual(got, tt.want) {
+			got, err := LoadProvider(tt.args.k, tt.args.t)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LoadProvider() = %v, want %v", got, tt.want)
 			}
 		})

--- a/alg-ps/ps_test.go
+++ b/alg-ps/ps_test.go
@@ -106,7 +106,7 @@ func TestProvider_Sign(t *testing.T) {
 
 func TestProvider_Verify(t *testing.T) {
 	p := Provider{set: KeySet{canVerify: false}}
-	if p.Verify(nil, nil, jwt.Header{}) != false {
-		t.Error("Verify() did not return false when canVerify is false")
+	if p.Verify(nil, nil, jwt.Header{}) == nil {
+		t.Error("Verify() did not return an error when canVerify is false")
 	}
 }

--- a/alg-ps/ps_test.go
+++ b/alg-ps/ps_test.go
@@ -85,8 +85,8 @@ func TestProvider_Header(t *testing.T) {
 func TestProvider_Sign(t *testing.T) {
 	// CanSign == false
 	p := Provider{set: KeySet{canSign: false}}
-	if p.Sign(nil) != nil {
-		t.Error("Sign() did not return nil when canSign is false")
+	if _, err := p.Sign(nil); err == nil {
+		t.Error("Sign() did not return an error when canSign is false")
 	}
 
 	// Save default rand.Reader
@@ -96,8 +96,8 @@ func TestProvider_Sign(t *testing.T) {
 	priv := &rsa.PrivateKey{PublicKey: rsa.PublicKey{N: big.NewInt(3603479687), E: 65537}, D: big.NewInt(674849825), Primes: []*big.Int{big.NewInt(64063), big.NewInt(56249)}, Precomputed: rsa.PrecomputedValues{Dp: big.NewInt(20717), Dq: big.NewInt(42569), Qinv: big.NewInt(7600), CRTValues: []rsa.CRTValue{}}}
 	rand.Reader = bytes.NewReader(nil)
 	p = Provider{pssopts: &rsa.PSSOptions{SaltLength: 32, Hash: crypto.SHA256}, set: KeySet{private: priv, canSign: true}}
-	if p.Sign(nil) != nil {
-		t.Error("Sign() did not return nil when no random data was available to generate signature")
+	if _, err := p.Sign(nil); err == nil {
+		t.Error("Sign() did not return an error when no random data was available to generate signature")
 	}
 
 	// Restore default rand.Reader

--- a/alg-ps/ps_test.go
+++ b/alg-ps/ps_test.go
@@ -111,8 +111,12 @@ func TestProvider_Sign(t *testing.T) {
 }
 
 func TestProvider_Verify(t *testing.T) {
-	p := Provider{set: KeySet{canVerify: false}}
+	p := Provider{pssopts: &rsa.PSSOptions{SaltLength: 32, Hash: crypto.SHA256}, set: KeySet{public: &rsa.PublicKey{N: big.NewInt(3603479687), E: 65537}, canVerify: false}}
 	if p.Verify(nil, nil, jwt.Header{}) == nil {
+		t.Error("Verify() did not return an error when canVerify is false")
+	}
+	p.set.canVerify = true
+	if p.Verify([]byte("test"), []byte("signature"), jwt.Header{}) == nil {
 		t.Error("Verify() did not return an error when canVerify is false")
 	}
 }

--- a/alg-rs/rs.go
+++ b/alg-rs/rs.go
@@ -93,17 +93,17 @@ func (p Provider) Header(h *jwt.Header) {
 }
 
 // Sign signs the content of a JWT
-func (p Provider) Sign(c []byte) []byte {
+func (p Provider) Sign(c []byte) ([]byte, error) {
 	if !p.set.canSign {
-		return nil
+		return nil, errors.New("keyset does not allow signing")
 	}
 	hash := p.hash.New()
 	hash.Write(c)
 	sum, err := rsa.SignPKCS1v15(rand.Reader, p.set.private, p.hash, hash.Sum(nil))
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return sum
+	return sum, nil
 }
 
 // Verify verifies if the content matches it's signature.

--- a/alg-rs/rs.go
+++ b/alg-rs/rs.go
@@ -69,16 +69,16 @@ func NewProviderWithKeyURL(t, keyURL string) (Provider, []publickey.PublicKey, e
 }
 
 // LoadProvider returns a Provider using the supplied keypairs
-func LoadProvider(k KeySet, t string) Provider {
+func LoadProvider(k KeySet, t string) (Provider, error) {
 	switch t {
 	case RS256:
-		return Provider{RS256, crypto.SHA256, k}
+		return Provider{RS256, crypto.SHA256, k}, nil
 	case RS384:
-		return Provider{RS384, crypto.SHA384, k}
+		return Provider{RS384, crypto.SHA384, k}, nil
 	case RS512:
-		return Provider{RS512, crypto.SHA512, k}
+		return Provider{RS512, crypto.SHA512, k}, nil
 	}
-	return Provider{}
+	return Provider{}, errors.New("type string invalid")
 }
 
 // Header sets the necessary JWT header fields

--- a/alg-rs/rs.go
+++ b/alg-rs/rs.go
@@ -107,11 +107,14 @@ func (p Provider) Sign(c []byte) ([]byte, error) {
 }
 
 // Verify verifies if the content matches it's signature.
-func (p Provider) Verify(data, sig []byte, _ jwt.Header) bool {
+func (p Provider) Verify(data, sig []byte, _ jwt.Header) error {
 	if !p.set.canVerify {
-		return false
+		return errors.New("keyset does not allow validation")
 	}
 	hash := p.hash.New()
 	hash.Write(data)
-	return rsa.VerifyPKCS1v15(p.set.public, p.hash, hash.Sum(nil), sig) == nil
+	if rsa.VerifyPKCS1v15(p.set.public, p.hash, hash.Sum(nil), sig) == nil {
+		return nil
+	}
+	return errors.New("signature invalid")
 }

--- a/alg-rs/rs_test.go
+++ b/alg-rs/rs_test.go
@@ -106,7 +106,7 @@ func TestProvider_Sign(t *testing.T) {
 
 func TestProvider_Verify(t *testing.T) {
 	p := Provider{set: KeySet{canVerify: false}}
-	if p.Verify(nil, nil, jwt.Header{}) != false {
-		t.Error("Verify() did not return false when canVerify is false")
+	if p.Verify(nil, nil, jwt.Header{}) == nil {
+		t.Error("Verify() did not return an error when canVerify is false")
 	}
 }

--- a/alg-rs/rs_test.go
+++ b/alg-rs/rs_test.go
@@ -85,8 +85,8 @@ func TestProvider_Header(t *testing.T) {
 func TestProvider_Sign(t *testing.T) {
 	// CanSign == false
 	p := Provider{set: KeySet{canSign: false}}
-	if p.Sign(nil) != nil {
-		t.Error("Sign() did not return nil when canSign is false")
+	if _, err := p.Sign(nil); err == nil {
+		t.Error("Sign() did not return an error when canSign is false")
 	}
 
 	// Save default rand.Reader
@@ -96,8 +96,8 @@ func TestProvider_Sign(t *testing.T) {
 	priv := &rsa.PrivateKey{PublicKey: rsa.PublicKey{N: big.NewInt(3603479687), E: 65537}, D: big.NewInt(674849825), Primes: []*big.Int{big.NewInt(64063), big.NewInt(56249)}, Precomputed: rsa.PrecomputedValues{Dp: big.NewInt(20717), Dq: big.NewInt(42569), Qinv: big.NewInt(7600), CRTValues: []rsa.CRTValue{}}}
 	rand.Reader = bytes.NewReader(nil)
 	p = Provider{hash: crypto.SHA256, set: KeySet{private: priv, canSign: true}}
-	if p.Sign(nil) != nil {
-		t.Error("Sign() did not return nil when no random data was available to generate signature")
+	if _, err := p.Sign(nil); err == nil {
+		t.Error("Sign() did not return an error when no random data was available to generate signature")
 	}
 
 	// Restore default rand.Reader

--- a/alg-rs/rs_test.go
+++ b/alg-rs/rs_test.go
@@ -45,18 +45,24 @@ func TestLoadProvider(t *testing.T) {
 		t string
 	}
 	tests := []struct {
-		name string
-		args args
-		want Provider
+		name    string
+		args    args
+		want    Provider
+		wantErr bool
 	}{
-		{"RS256", args{KeySet{}, RS256}, Provider{RS256, crypto.SHA256, KeySet{}}},
-		{"RS384", args{KeySet{}, RS384}, Provider{RS384, crypto.SHA384, KeySet{}}},
-		{"RS512", args{KeySet{}, RS512}, Provider{RS512, crypto.SHA512, KeySet{}}},
-		{"Unknown type", args{KeySet{}, "unknown"}, Provider{}},
+		{"RS256", args{KeySet{}, RS256}, Provider{RS256, crypto.SHA256, KeySet{}}, false},
+		{"RS384", args{KeySet{}, RS384}, Provider{RS384, crypto.SHA384, KeySet{}}, false},
+		{"RS512", args{KeySet{}, RS512}, Provider{RS512, crypto.SHA512, KeySet{}}, false},
+		{"Unknown type", args{KeySet{}, "unknown"}, Provider{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := LoadProvider(tt.args.k, tt.args.t); !reflect.DeepEqual(got, tt.want) {
+			got, err := LoadProvider(tt.args.k, tt.args.t)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LoadProvider() = %v, want %v", got, tt.want)
 			}
 		})

--- a/alg-rs/rs_test.go
+++ b/alg-rs/rs_test.go
@@ -111,8 +111,12 @@ func TestProvider_Sign(t *testing.T) {
 }
 
 func TestProvider_Verify(t *testing.T) {
-	p := Provider{set: KeySet{canVerify: false}}
+	p := Provider{hash: crypto.SHA256, set: KeySet{public: &rsa.PublicKey{N: big.NewInt(3603479687), E: 65537}, canVerify: false}}
 	if p.Verify(nil, nil, jwt.Header{}) == nil {
+		t.Error("Verify() did not return an error when canVerify is false")
+	}
+	p.set.canVerify = true
+	if p.Verify([]byte("test"), []byte("signature"), jwt.Header{}) == nil {
 		t.Error("Verify() did not return an error when canVerify is false")
 	}
 }

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -16,8 +16,11 @@ func (alg TestAlgorithm) Sign(data []byte) ([]byte, error) {
 	return append([]byte(alg), data...), nil
 }
 
-func (alg TestAlgorithm) Verify(data, hash []byte, h Header) bool {
-	return len(hash) == len(data)+len(alg)
+func (alg TestAlgorithm) Verify(data, hash []byte, h Header) error {
+	if len(hash) == len(data)+len(alg) {
+		return nil
+	}
+	return errors.New("token invalid")
 }
 
 func (alg TestAlgorithm) Header(h *Header) {

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -8,8 +8,8 @@ import (
 
 type TestAlgorithm string
 
-func (alg TestAlgorithm) Sign(data []byte) []byte {
-	return append([]byte(alg), data...)
+func (alg TestAlgorithm) Sign(data []byte) ([]byte, error) {
+	return append([]byte(alg), data...), nil
 }
 
 func (alg TestAlgorithm) Verify(data, hash []byte, h Header) bool {

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -9,6 +10,9 @@ import (
 type TestAlgorithm string
 
 func (alg TestAlgorithm) Sign(data []byte) ([]byte, error) {
+	if string(alg) == "error" {
+		return nil, errors.New("Here's the error you requested")
+	}
 	return append([]byte(alg), data...), nil
 }
 

--- a/encode.go
+++ b/encode.go
@@ -13,7 +13,7 @@ func New(content []byte) JWT {
 }
 
 // Encode a JWT to a byte slice
-func (t JWT) Encode() (result []byte, err error) {
+func (t JWT) Encode() ([]byte, error) {
 	if defaultAlgorithm == "" {
 		return nil, errors.New("default algorithm is not set - cannot sign JWT")
 	}
@@ -24,9 +24,12 @@ func (t JWT) Encode() (result []byte, err error) {
 	alg.Header(&t.Header)
 	header := encodeHeader(t.Header)
 	content := b64encode(t.Content)
-	hash := b64encode(alg.Sign(join(header, content)))
-	result = join(header, content, hash)
-	return
+	sig, err := alg.Sign(join(header, content))
+	if err != nil {
+		return nil, err
+	}
+	hash := b64encode(sig)
+	return join(header, content, hash), nil
 }
 
 func b64encode(data []byte) []byte {

--- a/encode_test.go
+++ b/encode_test.go
@@ -89,18 +89,20 @@ func Test_encodeHeader(t *testing.T) {
 }
 
 func TestJWT_Encode(t *testing.T) {
-	SetAlgorithm("test", TestAlgorithm("test"))
-	DefaultAlgorithm("test")
 	tests := []struct {
 		name       string
 		t          JWT
+		alg        Algorithm
 		wantResult []byte
 		wantErr    bool
 	}{
-		{"Normal", JWT{Header{Typ: "JWT"}, []byte("{\"name\":\"test\",\"use\":\"testing\"}"), nil}, []byte("eyJ0eXAiOiJKV1QiLCJhbGciOiJ0ZXN0In0.eyJuYW1lIjoidGVzdCIsInVzZSI6InRlc3RpbmcifQ.dGVzdGV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSjBaWE4wSW4wLmV5SnVZVzFsSWpvaWRHVnpkQ0lzSW5WelpTSTZJblJsYzNScGJtY2lmUQ"), false},
+		{"Normal", JWT{Header{Typ: "JWT"}, []byte("{\"name\":\"test\",\"use\":\"testing\"}"), nil}, TestAlgorithm("test"), []byte("eyJ0eXAiOiJKV1QiLCJhbGciOiJ0ZXN0In0.eyJuYW1lIjoidGVzdCIsInVzZSI6InRlc3RpbmcifQ.dGVzdGV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSjBaWE4wSW4wLmV5SnVZVzFsSWpvaWRHVnpkQ0lzSW5WelpTSTZJblJsYzNScGJtY2lmUQ"), false},
+		{"Fail", JWT{Header{Typ: "JWT"}, []byte("{\"name\":\"test\",\"use\":\"testing\"}"), nil}, TestAlgorithm("error"), nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			SetAlgorithm("test", tt.alg)
+			DefaultAlgorithm("test")
 			gotResult, err := tt.t.Encode()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JWT.Encode() error = %v, wantErr %v", err, tt.wantErr)

--- a/types.go
+++ b/types.go
@@ -18,7 +18,7 @@ type JWT struct {
 
 // Algorithm is an interface for algorithms used to sign and validate a JWS
 type Algorithm interface {
-	Sign([]byte) []byte
+	Sign([]byte) ([]byte, error)
 	Verify([]byte, []byte, Header) bool
 	Header(*Header)
 }

--- a/types.go
+++ b/types.go
@@ -19,6 +19,6 @@ type JWT struct {
 // Algorithm is an interface for algorithms used to sign and validate a JWS
 type Algorithm interface {
 	Sign([]byte) ([]byte, error)
-	Verify([]byte, []byte, Header) bool
+	Verify([]byte, []byte, Header) error
 	Header(*Header)
 }

--- a/validate.go
+++ b/validate.go
@@ -19,8 +19,8 @@ func (jwt JWT) validate(data, signature []byte) error {
 	}
 
 	// Check the hash using the Verify function of the algorithm declared by the header
-	if !alg.Verify(data, signature, jwt.Header) {
-		return errors.New("hash does not match content")
+	if err := alg.Verify(data, signature, jwt.Header); err != nil {
+		return err
 	}
 
 	return checkTimestamps(jwt.Content)


### PR DESCRIPTION
In this PR I will add errors as a return value to most signature provider functions to make handling issue easier. The providers should therefore work without panics and nil return values.

A document containing the API definitions is also included.

During the implementation I also have consolidated the signature providers of HMAC-SHA2 into a single type.